### PR TITLE
I believe eval-after-load only takes 2 arguments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ Add the following to your `init.el`:
 
 ``` emacs-lisp
 (eval-after-load 'flymake
-  (require 'flymake-diagnostic-at-point)
-  (add-hook 'flymake-mode-hook #'flymake-diagnostic-at-point-mode))
+  (progn
+    (require 'flymake-diagnostic-at-point)
+    (add-hook 'flymake-mode-hook #'flymake-diagnostic-at-point-mode)))
 ```
 
 Alternatively, if you prefer using `use-package`:


### PR DESCRIPTION
When I added your module to my .emacs file based on
your eval-after-load code, it gave me an invalid number of arguments error.

The progn should make this work correctly.