### PR TITLE
Add ability to configure function for hiding diagnostic

### DIFF
--- a/flymake-diagnostic-at-point.el
+++ b/flymake-diagnostic-at-point.el
@@ -58,6 +58,12 @@
                         flymake-diagnostic-at-point-display-minibuffer)
                  (function :tag "Error display function")))
 
+(defcustom flymake-diagnostic-at-point-hide-diagnostic-function 'nil
+  "The function to be used to hide the diagnostic message (if needed)."
+  :group 'flymake-diagnostic-at-point
+  :type '(choice (const :tag "None" nil)
+                 (function :tag "Error hide function")))
+
 (defvar-local flymake-diagnostic-at-point-timer nil
   "Timer to automatically show the error at point.")
 
@@ -78,10 +84,12 @@
 
 The diagnostic text will be rendered using the function defined
 in `flymake-diagnostic-at-point-display-diagnostic-function.'"
-  (when (and flymake-mode
-             (get-char-property (point) 'flymake-diagnostic))
-    (let ((text (flymake-diagnostic-at-point-get-diagnostic-text)))
-      (funcall flymake-diagnostic-at-point-display-diagnostic-function text))))
+  (if (and flymake-mode
+           (get-char-property (point) 'flymake-diagnostic))
+      (let ((text (flymake-diagnostic-at-point-get-diagnostic-text)))
+        (funcall flymake-diagnostic-at-point-display-diagnostic-function text))
+    (when flymake-diagnostic-at-point-hide-diagnostic-function
+      (funcall flymake-diagnostic-at-point-hide-diagnostic-function))))
 
 ;;;###autoload
 (defun flymake-diagnostic-at-point-set-timer ()


### PR DESCRIPTION
I wanted to adopt this function to use it with [quick-peek](https://github.com/cpitclaudel/quick-peek).

However `quick-peek` does not take care of hiding the diagnostic by itself. I figured I could add a configurable variable to configure a function that will be run inside the maybe display function, if point had moved away.

Here is a working example:
```
(defun flymake-diagnostic-at-point-quick-peek (text)
  "Display the flymake diagnostic TEXT with `quick-peek'`."
  (quick-peek-show (concat flymake-diagnostic-at-point-error-prefix text)))

(setq 
  flymake-diagnostic-at-point-display-diagnostic-function #'flymake-diagnostic-at-point-quick-peek
  flymake-diagnostic-at-point-hide-diagnostic-function #'quick-peek-hide)
```

I configured the function to be `nil` to retain the default behavior. Feel free to include support for `quick-peek` or just add this function and let it be up to the users themselves.

Thanks for this package, cheers!