### PR TITLE
Fix message

### DIFF
--- a/flymake-diagnostic-at-point.el
+++ b/flymake-diagnostic-at-point.el
@@ -71,7 +71,7 @@
 
 (defun flymake-diagnostic-at-point-display-minibuffer (text)
   "Display the flymake diagnostic TEXT in the minibuffer."
-  (message (concat flymake-diagnostic-at-point-error-prefix text)))
+  (message "%s" (concat flymake-diagnostic-at-point-error-prefix text)))
 
 (defun flymake-diagnostic-at-point-maybe-display ()
   "Display the flymake diagnostic text for the thing at point.


### PR DESCRIPTION
`(message error-message)` is problematic, for example, the `error-message` can contains `%s`.