### PR TITLE
Remove deprecated `flymake--diag-text` to fix display bug [#9]

### DIFF
--- a/flymake-diagnostic-at-point.el
+++ b/flymake-diagnostic-at-point.el
@@ -74,10 +74,10 @@
 
 The diagnostic text will be rendered using the function defined
 in `flymake-diagnostic-at-point-display-diagnostic-function.'"
-  (when (and flymake-mode
-             (get-char-property (point) 'flymake-diagnostic))
-    (let ((text (flymake-diagnostic-message (get-char-property (point) 'flymake-diagnostic))))
-      (funcall flymake-diagnostic-at-point-display-diagnostic-function text))))
+  (when (flymake-mode)
+    (if-let* ((diag (get-char-property (point) 'flymake-diagnostic))
+              (message (flymake-diagnostic-message diag)))
+        (funcall flymake-diagnostic-at-point-display-diagnostic-function message))))
 
 ;;;###autoload
 (defun flymake-diagnostic-at-point-set-timer ()

--- a/flymake-diagnostic-at-point.el
+++ b/flymake-diagnostic-at-point.el
@@ -61,10 +61,6 @@
 (defvar-local flymake-diagnostic-at-point-timer nil
   "Timer to automatically show the error at point.")
 
-(defun flymake-diagnostic-at-point-get-diagnostic-text ()
-  "Get the flymake diagnostic text for the thing at point."
-  (flymake--diag-text (get-char-property (point) 'flymake-diagnostic)))
-
 (defun flymake-diagnostic-at-point-display-popup (text)
   "Display the flymake diagnostic TEXT inside a popup."
   (popup-tip (concat flymake-diagnostic-at-point-error-prefix text)))
@@ -80,7 +76,7 @@ The diagnostic text will be rendered using the function defined
 in `flymake-diagnostic-at-point-display-diagnostic-function.'"
   (when (and flymake-mode
              (get-char-property (point) 'flymake-diagnostic))
-    (let ((text (flymake-diagnostic-at-point-get-diagnostic-text)))
+    (let ((text (flymake-diagnostic-message (get-char-property (point) 'flymake-diagnostic))))
       (funcall flymake-diagnostic-at-point-display-diagnostic-function text))))
 
 ;;;###autoload


### PR DESCRIPTION
Resolves #9.

- Update `flymake-diagnostic-at-point-maybe-display` to just get the text directly
- Remove the now unused and broken `flymake-diagnostic-at-point-get-diagnostic-text`